### PR TITLE
Fix undefined args variable

### DIFF
--- a/force.js
+++ b/force.js
@@ -117,6 +117,8 @@ getResponse().then((result) => {
 
 // Stuff for easier debugging in Visual Studio Code
 function getResponse() {
+	const args = process.argv; 
+
 	if (isDebugging() === true) {
 		return new Promise((resolve, reject) => {
 			resolve({


### PR DESCRIPTION
I was test latest version of `force.js`. **I was get this error:**
![image](https://user-images.githubusercontent.com/25010528/90712886-ac3aac00-e2ac-11ea-952a-3449c58c3cf4.png)

Also I was check code of `force.js` and you didn't define any of `args`. Did you mistake? :eyes:
So, I was add a few (actualy only one line) lines with fix this.
I already test it so it is 100% work.

PS: Yea, I can rename variable `args` to `argv`, but I didn't want change more like one line. So ... if you want, @BeepIsla, I can change name of args variable.  