### PR TITLE
Add Check If Suspect Exist In This Demo

### DIFF
--- a/force.js
+++ b/force.js
@@ -71,6 +71,7 @@ getResponse().then((result) => {
 		function getPlayerIndex() {
 			const filtered = demoFile.players.filter(p => p.userInfo !== null);
 			playerIndex = filtered.map(p => p.steamId === "BOT" ? p.steamId : new SteamID(p.steamId).getSteamID64()).indexOf(sid.getSteamID64());
+			if (suspectIsExist) return;
 			suspectIsExist = filtered.find(p => p.steam64Id === sid.getSteamID64()) ? true : false // Check if suspect is exist on this tick of demo
 		}
 


### PR DESCRIPTION
@BeepIsla 
How I said in #75 issue, I want add check for suspect if him is exist.
If suspect is not exist show error message to user what this guy is unknown for us and try again or ... any else.

> Actualy, I didn't test it for POV demo by 100%, but how I see, bot didn't work with POV demos so .... this is not a trouble :d

#### Test with not exist user:

![image](https://user-images.githubusercontent.com/25010528/90948822-4afd0f00-e44b-11ea-9c10-1627aeaacc06.png)

[In 74 line I was add check.](https://github.com/BeepIsla/CSGO-Overwatch-Bot/compare/master...BlackYuzia:suspect_exist_check?diff=split#diff-1a7c4daaf24c4425de4bcd71b57baf12R74)
Also, I saw what you **filter** players without info [in line 72.](https://github.com/BeepIsla/CSGO-Overwatch-Bot/compare/master...BlackYuzia:suspect_exist_check?diff=split#diff-1a7c4daaf24c4425de4bcd71b57baf12R72) so I was use filtered players too.

Oh yep. Maybe that is COOL, BEST, 1337 Code Style but I remove it in my repo :eyes: 
I can revert this changes if you want and create PR without this feature :3

#### Style Code Changes:

[First Change](https://github.com/BeepIsla/CSGO-Overwatch-Bot/compare/master...BlackYuzia:suspect_exist_check?diff=split#diff-1a7c4daaf24c4425de4bcd71b57baf12R44)
[Second Change](https://github.com/BeepIsla/CSGO-Overwatch-Bot/compare/master...BlackYuzia:suspect_exist_check?diff=split#diff-1a7c4daaf24c4425de4bcd71b57baf12R49)
[Third Change](https://github.com/BeepIsla/CSGO-Overwatch-Bot/compare/master...BlackYuzia:suspect_exist_check?diff=split#diff-1a7c4daaf24c4425de4bcd71b57baf12R127)

PS: Yep, I was test this. All is success work. But you can try test manualy.
