### PR TITLE
Add AA detector feature [beta]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ config.json
 test.js
 manualLogin.js
 cases
+.idea

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ You can forcefully parse a demo by simply putting it in the directory and runnin
 - - `maxVerdicts`: The maximum amount of cases we want to do. 0 for infinite
 - - `maxAimbot`: The maximum amount of infractions allowed before setting user as aimbotter
 - - `maxWallKills`: Maximum amount of allowed kills through a wall before setting user as wallhacking
+- - `maxTeamKills`: Maximum amount of allowed kills Team  
 - - `maxAFKing`: The maximum amount of infractions allowed before setting user as griefing
 - `richPresence`
 - - `steam_display`: What information to display on Steam - [Read more](#rich-presence)

--- a/README.md
+++ b/README.md
@@ -46,7 +46,8 @@ You can forcefully parse a demo by simply putting it in the directory and runnin
 - - `maxVerdicts`: The maximum amount of cases we want to do. 0 for infinite
 - - `maxAimbot`: The maximum amount of infractions allowed before setting user as aimbotter
 - - `maxWallKills`: Maximum amount of allowed kills through a wall before setting user as wallhacking
-- - `maxTeamKills`: Maximum amount of allowed kills Team  
+- - `maxTeamKills`: Maximum amount of allowed kills Team 
+- - `maxTeamDamage`: Maximum amount of damage to the team based on the total health taken from all allies 
 - - `maxAFKing`: The maximum amount of infractions allowed before setting user as griefing
 - `richPresence`
 - - `steam_display`: What information to display on Steam - [Read more](#rich-presence)

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ You can forcefully parse a demo by simply putting it in the directory and runnin
 5. Make a duplicate of the `config.json.example` and remove the `.example`
 6. Adjust your now called `config.json` - [See Config](#config)
 7. Run `node index.js`
-8. After every update repeat from step 3 onwards to ensure everything required is up to date
+8. After every update repeat from step 2 onwards to ensure everything required is up to date
 
 # Detections
 

--- a/config.json.example
+++ b/config.json.example
@@ -22,6 +22,7 @@
 		"maxAimbot": 10,
 		"maxWallKills": 7,
 		"maxTeamKills": 1,
+		"maxTeamDamage" 180,
 		"maxAFKing": 3
 	},
 	"richPresence": {

--- a/config.json.example
+++ b/config.json.example
@@ -21,6 +21,7 @@
 		"maxVerdicts": 0,
 		"maxAimbot": 10,
 		"maxWallKills": 7,
+		"maxTeamKills": 1,
 		"maxAFKing": 3
 	},
 	"richPresence": {

--- a/config.json.example
+++ b/config.json.example
@@ -22,7 +22,7 @@
 		"maxAimbot": 10,
 		"maxWallKills": 7,
 		"maxTeamKills": 1,
-		"maxTeamDamage" 180,
+		"maxTeamDamage": 180,
 		"maxAFKing": 3
 	},
 	"richPresence": {

--- a/detectors/AA.js
+++ b/detectors/AA.js
@@ -1,0 +1,26 @@
+module.exports = (demoFile, sid, data) => {
+    let array = [];
+
+    const array2 = demoFile.on("tickend__", (tick) => {
+        let ourPlayer = demoFile.players[tick.player];
+        if (typeof ourPlayer === "undefined") {
+            return;
+        }
+        if (ourPlayer.isAlive) {
+            const eyeAngles = ourPlayer.eyeAngles;
+            const m_flLowerBodyYawTarget = ourPlayer.getProp("DT_CSPlayer", "m_flLowerBodyYawTarget");
+            const lbyDelta = m_flLowerBodyYawTarget - ourPlayer.eyeAngles.yaw;
+
+            // Check if player look at floor and check angles
+            // ! Be aware. This detector is unstable. 
+            // ! I don't sure by 100%, but if player just look at floor (0deg) and didn't kill anybody
+            // ! this detector can say what he have AntiAim (AA)... need more tests!
+            // ? Source: https://www.unknowncheats.me/forum/counterstrike-global-offensive/208735-detecting-player-antiaim.html
+            if (lbyDelta > 40 && ourPlayer.eyeAngles.pitch === 0) {
+                console.log(m_flLowerBodyYawTarget, "X,Y,Z:", ourPlayer.eyeAngles.yaw, ourPlayer.eyeAngles.pitch, 0, lbyDelta);
+                return data.curcasetempdata.AA_infractions.push({ eyeAngles, lbyDelta });
+            };
+            return;
+        }
+    });
+}

--- a/detectors/AA.js
+++ b/detectors/AA.js
@@ -1,7 +1,5 @@
 module.exports = (demoFile, sid, data) => {
-    let array = [];
-
-    const array2 = demoFile.on("tickend__", (tick) => {
+    demoFile.on("tickend__", (tick) => {
         let ourPlayer = demoFile.players[tick.player];
         if (typeof ourPlayer === "undefined") {
             return;
@@ -15,12 +13,10 @@ module.exports = (demoFile, sid, data) => {
             // ! Be aware. This detector is unstable. 
             // ! I don't sure by 100%, but if player just look at floor (0deg) and didn't kill anybody
             // ! this detector can say what he have AntiAim (AA)... need more tests!
-            // ? Source: https://www.unknowncheats.me/forum/counterstrike-global-offensive/208735-detecting-player-antiaim.html
+            // ? Idea: https://www.unknowncheats.me/forum/counterstrike-global-offensive/208735-detecting-player-antiaim.html
             if (lbyDelta > 40 && ourPlayer.eyeAngles.pitch === 0) {
-                console.log(m_flLowerBodyYawTarget, "X,Y,Z:", ourPlayer.eyeAngles.yaw, ourPlayer.eyeAngles.pitch, 0, lbyDelta);
-                return data.curcasetempdata.AA_infractions.push({ eyeAngles, lbyDelta });
+                data.curcasetempdata.AA_infractions.push({ eyeAngles, lbyDelta });
             };
-            return;
         }
     });
 }

--- a/detectors/teamDamage.js
+++ b/detectors/teamDamage.js
@@ -1,16 +1,14 @@
 module.exports = (demoFile, sid, data) => {
-    demoFile.gameEvents.on("player_death", (event) => {
+    //TODO exclude motolov and Incendiary damge, "TROLL TEAM"
+    demoFile.gameEvents.on("player_hurt", (event) => {
         const victim = demoFile.entities.getByUserId(event.userid);
         const attacker = demoFile.entities.getByUserId(event.attacker);
         if (!attacker || attacker.steam64Id === "BOT" || attacker.steam64Id !== sid.getSteamID64() || victim === attacker) {
             return;
         }
-        /**
-         * @returns Team number (0: Unassigned, 1: Spectator, 2: Terrorist, 3: Counter-Terrorist)
-         */
         if(attacker.teamNumber === victim.teamNumber){
-            data.curcasetempdata.teamKill_infractions.push(demoFile.currentTick);
-            //console.log("TK")
+            data.curcasetempdata.teamDamage_infractions += event.dmg_health;
+            //console.log(event.weapon);
         }
 
     })

--- a/detectors/teamDamage.js
+++ b/detectors/teamDamage.js
@@ -3,7 +3,7 @@ module.exports = (demoFile, sid, data) => {
     demoFile.gameEvents.on("player_hurt", (event) => {
         const victim = demoFile.entities.getByUserId(event.userid);
         const attacker = demoFile.entities.getByUserId(event.attacker);
-        if (!attacker || attacker.steam64Id === "BOT" || attacker.steam64Id !== sid.getSteamID64() || victim === attacker) {
+        if (!victim || !attacker || attacker.steam64Id === "BOT" || attacker.steam64Id !== sid.getSteamID64() || victim === attacker) {
             return;
         }
         if(attacker.teamNumber === victim.teamNumber){

--- a/detectors/teamDamage.js
+++ b/detectors/teamDamage.js
@@ -6,7 +6,11 @@ module.exports = (demoFile, sid, data) => {
         if (!victim || !attacker || attacker.steam64Id === "BOT" || attacker.steam64Id !== sid.getSteamID64() || victim === attacker) {
             return;
         }
-        if(attacker.teamNumber === victim.teamNumber){
+        isNotMolotovInc = (event) => {
+            return event.weapon != "incgrenade" && event.weapon != "molotov";
+        }
+
+        if(attacker.teamNumber === victim.teamNumber && isNotMolotovInc(event)){
             data.curcasetempdata.teamDamage_infractions += event.dmg_health;
             //console.log(event.weapon);
         }

--- a/detectors/teamDamage.js
+++ b/detectors/teamDamage.js
@@ -10,7 +10,7 @@ module.exports = (demoFile, sid, data) => {
             return event.weapon != "incgrenade" && event.weapon != "molotov";
         }
 
-        if(attacker.teamNumber === victim.teamNumber && isNotMolotovInc(event)){
+        if(attacker.isFriendly(victim) && isNotMolotovInc(event)){
             data.curcasetempdata.teamDamage_infractions += event.dmg_health;
             //console.log(event.weapon);
         }

--- a/detectors/teamkill.js
+++ b/detectors/teamkill.js
@@ -3,7 +3,7 @@ module.exports = (demoFile, sid, data) => {
     demoFile.gameEvents.on("player_death", (event) => {
         const victim = demoFile.entities.getByUserId(event.userid);
         const attacker = demoFile.entities.getByUserId(event.attacker);
-        if (!attacker || attacker.steam64Id === "BOT" || attacker.steam64Id !== sid.getSteamID64()) {
+        if (!attacker || attacker.steam64Id === "BOT" || attacker.steam64Id !== sid.getSteamID64() || victim === attacker) {
             return;
         }
         /**

--- a/detectors/teamkill.js
+++ b/detectors/teamkill.js
@@ -8,7 +8,7 @@ module.exports = (demoFile, sid, data) => {
         if (!victim || !attacker || attacker.steam64Id === "BOT" || attacker.steam64Id !== sid.getSteamID64() || victim === attacker) {
             return;
         }
-        if(attacker.teamNumber === victim.teamNumber && isNotMolotovInc(event)){
+        if(attacker.isFriendly(victim) && isNotMolotovInc(event)){
             data.curcasetempdata.teamKill_infractions.push(demoFile.currentTick);
         }
 

--- a/detectors/teamkill.js
+++ b/detectors/teamkill.js
@@ -1,0 +1,18 @@
+module.exports = (demoFile, sid, data) => {
+    //TODO role in base damage player_hurt userid attacker dmg_health or dmg_armor
+    demoFile.gameEvents.on("player_death", (event) => {
+        const victim = demoFile.entities.getByUserId(event.userid);
+        const attacker = demoFile.entities.getByUserId(event.attacker);
+        if (!attacker || attacker.steam64Id === "BOT" || attacker.steam64Id !== sid.getSteamID64()) {
+            return;
+        }
+        /**
+         * @returns Team number (0: Unassigned, 1: Spectator, 2: Terrorist, 3: Counter-Terrorist)
+         */
+        if(attacker.teamNumber === victim.teamNumber){
+            data.curcasetempdata.teamKill_infractions.push(demoFile.currentTick);
+            //console.log("TK")
+        }
+
+    })
+};

--- a/detectors/teamkill.js
+++ b/detectors/teamkill.js
@@ -2,15 +2,14 @@ module.exports = (demoFile, sid, data) => {
     demoFile.gameEvents.on("player_death", (event) => {
         const victim = demoFile.entities.getByUserId(event.userid);
         const attacker = demoFile.entities.getByUserId(event.attacker);
-        if (!attacker || attacker.steam64Id === "BOT" || attacker.steam64Id !== sid.getSteamID64() || victim === attacker) {
-            return;
-        }
         isNotMolotovInc = (event) => {
             return event.weapon != "incgrenade" && event.weapon != "molotov";
         }
+        if (!victim || !attacker || attacker.steam64Id === "BOT" || attacker.steam64Id !== sid.getSteamID64() || victim === attacker) {
+            return;
+        }
         if(attacker.teamNumber === victim.teamNumber && isNotMolotovInc(event)){
             data.curcasetempdata.teamKill_infractions.push(demoFile.currentTick);
-            //console.log("TK")
         }
 
     })

--- a/detectors/teamkill.js
+++ b/detectors/teamkill.js
@@ -5,10 +5,10 @@ module.exports = (demoFile, sid, data) => {
         if (!attacker || attacker.steam64Id === "BOT" || attacker.steam64Id !== sid.getSteamID64() || victim === attacker) {
             return;
         }
-        /**
-         * @returns Team number (0: Unassigned, 1: Spectator, 2: Terrorist, 3: Counter-Terrorist)
-         */
-        if(attacker.teamNumber === victim.teamNumber){
+        isNotMolotovInc = (event) => {
+            return event.weapon != "incgrenade" && event.weapon != "molotov";
+        }
+        if(attacker.teamNumber === victim.teamNumber && isNotMolotovInc(event)){
             data.curcasetempdata.teamKill_infractions.push(demoFile.currentTick);
             //console.log("TK")
         }

--- a/force.js
+++ b/force.js
@@ -117,6 +117,8 @@ getResponse().then((result) => {
 
 // Stuff for easier debugging in Visual Studio Code
 function getResponse() {
+	const args = process.argv; 
+
 	if (isDebugging() === true) {
 		return new Promise((resolve, reject) => {
 			resolve({

--- a/force.js
+++ b/force.js
@@ -68,7 +68,7 @@ getResponse().then((result) => {
 		demoFile.gameEvents.on("round_freeze_end", getPlayerIndex);
 
 		function getPlayerIndex() {
-			playerIndex = demoFile.players.map(p => p.steamId === "BOT" ? p.steamId : new SteamID(p.steamId).getSteamID64()).indexOf(sid.getSteamID64());
+			playerIndex = demoFile.players.filter(p => p.userInfo !== null).map(p => p.steamId === "BOT" ? p.steamId : new SteamID(p.steamId).getSteamID64()).indexOf(sid.getSteamID64());
 		}
 
 		demoFile.on("tickend", (curTick) => {

--- a/force.js
+++ b/force.js
@@ -7,6 +7,7 @@ const fs = require("fs");
 const Aimbot = require("./detectors/aimbot.js");
 const AFKing = require("./detectors/AFKing.js");
 const Wallhack = require("./detectors/wallhack.js");
+const TeamKill = require("./detectors/teamkill.js");
 
 const config = require("./config.json");
 
@@ -14,7 +15,8 @@ let data = {
 	curcasetempdata: {
 		aimbot_infractions: [],
 		AFKing_infractions: [],
-		Wallhack_infractions: []
+		Wallhack_infractions: [],
+		TeamKill_infractions: []
 	}
 };
 
@@ -101,6 +103,7 @@ getResponse().then((result) => {
 			console.log("Infractions:");
 			console.log("	Aimbot: " + data.curcasetempdata.aimbot_infractions.length);
 			console.log("	Wallhack: " + data.curcasetempdata.Wallhack_infractions.length);
+			console.log("	TeamKills: "+ data.curcasetempdata.TeamKill_infractions.length);
 			console.log("	Other: 0");
 			console.log("	Griefing: " + data.curcasetempdata.AFKing_infractions.length);
 		});

--- a/force.js
+++ b/force.js
@@ -124,6 +124,11 @@ function getResponse() {
 				suspect: "76561198976843261"
 			});
 		});
+	} else if (args[2] && args[3]) {
+		return Promise.resolve({
+			path: args[2],
+			suspect: args[3]
+		});
 	} else {
 		return inquire.prompt([
 			{

--- a/force.js
+++ b/force.js
@@ -9,6 +9,7 @@ const AFKing = require("./detectors/AFKing.js");
 const Wallhack = require("./detectors/wallhack.js");
 const TeamKill = require("./detectors/teamkill.js");
 const TeamDamage = require("./detectors/teamDamage.js");
+const AA = require("./detectors/AA.js");
 
 const config = require("./config.json");
 
@@ -18,7 +19,8 @@ let data = {
 		AFKing_infractions: [],
 		Wallhack_infractions: [],
 		teamKill_infractions: [],
-		teamDamage_infractions: 0
+		teamDamage_infractions: 0,
+                AA_infractions: []
 	}
 };
 
@@ -81,6 +83,7 @@ getResponse().then((result) => {
 		Wallhack(demoFile, sid, data, config);
 		TeamKill(demoFile, sid, data);
 		TeamDamage(demoFile, sid, data);
+                AA(demoFile, sid, data); // todo: remove sid
 
 		demoFile.on("progress", (progressFraction) => {
 			let prog = Math.round(progressFraction * 100);
@@ -106,6 +109,7 @@ getResponse().then((result) => {
 			console.log("Suspect: " + (sid ? sid.getSteamID64() : 0));
 			console.log("Infractions:");
 			console.log("	Aimbot: " + data.curcasetempdata.aimbot_infractions.length);
+                        console.log("	AA: " + data.curcasetempdata.AA_infractions.length); // ! Unstable
 			console.log("	Wallhack: " + data.curcasetempdata.Wallhack_infractions.length);
 			console.log("	TeamKills: "+ data.curcasetempdata.teamKill_infractions.length);
 			console.log("	TeamDamage: " + data.curcasetempdata.teamDamage_infractions);

--- a/force.js
+++ b/force.js
@@ -16,7 +16,7 @@ let data = {
 		aimbot_infractions: [],
 		AFKing_infractions: [],
 		Wallhack_infractions: [],
-		TeamKill_infractions: []
+		teamKill_infractions: []
 	}
 };
 
@@ -103,7 +103,7 @@ getResponse().then((result) => {
 			console.log("Infractions:");
 			console.log("	Aimbot: " + data.curcasetempdata.aimbot_infractions.length);
 			console.log("	Wallhack: " + data.curcasetempdata.Wallhack_infractions.length);
-			console.log("	TeamKills: "+ data.curcasetempdata.TeamKill_infractions.length);
+			console.log("	TeamKills: "+ data.curcasetempdata.teamKill_infractions.length);
 			console.log("	Other: 0");
 			console.log("	Griefing: " + data.curcasetempdata.AFKing_infractions.length);
 		});

--- a/force.js
+++ b/force.js
@@ -8,6 +8,7 @@ const Aimbot = require("./detectors/aimbot.js");
 const AFKing = require("./detectors/AFKing.js");
 const Wallhack = require("./detectors/wallhack.js");
 const TeamKill = require("./detectors/teamkill.js");
+const TeamDamage = require("./detectors/teamDamage.js");
 
 const config = require("./config.json");
 
@@ -16,7 +17,8 @@ let data = {
 		aimbot_infractions: [],
 		AFKing_infractions: [],
 		Wallhack_infractions: [],
-		teamKill_infractions: []
+		teamKill_infractions: [],
+		teamDamage_infractions: 0
 	}
 };
 
@@ -77,6 +79,8 @@ getResponse().then((result) => {
 		Aimbot(demoFile, sid, data, config);
 		AFKing(demoFile, sid, data, config);
 		Wallhack(demoFile, sid, data, config);
+		TeamKill(demoFile, sid, data);
+		TeamDamage(demoFile, sid, data);
 
 		demoFile.on("progress", (progressFraction) => {
 			let prog = Math.round(progressFraction * 100);
@@ -104,6 +108,7 @@ getResponse().then((result) => {
 			console.log("	Aimbot: " + data.curcasetempdata.aimbot_infractions.length);
 			console.log("	Wallhack: " + data.curcasetempdata.Wallhack_infractions.length);
 			console.log("	TeamKills: "+ data.curcasetempdata.teamKill_infractions.length);
+			console.log("	TeamDamage: " + data.curcasetempdata.teamDamage_infractions);
 			console.log("	Other: 0");
 			console.log("	Griefing: " + data.curcasetempdata.AFKing_infractions.length);
 		});

--- a/index.js
+++ b/index.js
@@ -52,7 +52,8 @@ let data = {
 		Wallhack_infractions: [],
 		teamKill_infractions: [],
 		Reported: false
-	}
+	},
+	steamProfile: ""
 };
 
 let logonSettings = {
@@ -379,6 +380,7 @@ async function doOverwatchCase() {
 
 							data.total.endTimestamp = Date.now();
 							data.casesCompleted++;
+							data.curcasetempdata.steamProfile = "https://steamcommunity.com/profiles/"+ sid.getSteamID64() + "/";
 
 							// Print logs
 							console.log("Internal ID: " + data.casesCompleted);

--- a/index.js
+++ b/index.js
@@ -10,6 +10,7 @@ const Aimbot = require("./detectors/aimbot.js");
 const AFKing = require("./detectors/AFKing.js");
 const Wallhack = require("./detectors/wallhack.js");
 const TeamKill = require("./detectors/teamkill.js");
+const TeamDamage = require("./detectors/teamDamage.js");
 
 const Helper = require("./helpers/Helper.js");
 const GameCoordinator = require("./helpers/GameCoordinator.js");
@@ -51,6 +52,7 @@ let data = {
 		AFKing_infractions: [],
 		Wallhack_infractions: [],
 		teamKill_infractions: [],
+		teamDamage_infractions: 0,
 		Reported: false
 	},
 	steamProfile: ""
@@ -233,6 +235,7 @@ async function doOverwatchCase() {
 						data.curcasetempdata.AFKing_infractions = [];
 						data.curcasetempdata.Wallhack_infractions = [];
 						data.curcasetempdata.teamKill_infractions = [];
+						data.curcasetempdata.teamDamage_infractions = 0;
 						data.curcasetempdata.wasAlreadyConvicted = false;
 
 						let lastProg = -1;
@@ -256,6 +259,7 @@ async function doOverwatchCase() {
 						AFKing(demoFile, sid, data, config);
 						Wallhack(demoFile, sid, data, config);
 						TeamKill(demoFile, sid, data);
+						TeamDamage(demoFile, sid, data);
 
 						demoFile.on("progress", (progressFraction) => {
 							let prog = Math.round(progressFraction * 100);
@@ -290,7 +294,8 @@ async function doOverwatchCase() {
 								rpt_aimbot: (data.curcasetempdata.aimbot_infractions.length > config.verdict.maxAimbot) ? 1 : 0,
 								rpt_wallhack: (data.curcasetempdata.Wallhack_infractions.length > config.verdict.maxWallKills) ? 1 : 0, // TODO: Add detection for looking at enemies through walls
 								rpt_speedhack: 0, // TODO: Add detection for other cheats (Ex BunnyHopping)
-								rpt_teamharm: (data.curcasetempdata.AFKing_infractions.length > config.verdict.maxAFKing || data.curcasetempdata.teamKill_infractions.length > config.verdict.maxTeamKills) ? 1 : 0, // TODO: Add detection for damaging teammates
+								rpt_teamharm:  (data.curcasetempdata.teamDamage_infractions > config.verdict.maxTeamDamage ||  data.curcasetempdata.AFKing_infractions.length > config.verdict.maxAFKing
+									|| data.curcasetempdata.teamKill_infractions.length > config.verdict.maxTeamKills) ? 1 : 0, // TODO: Add detection for damaging teammates
 								reason: 3
 							};
 
@@ -302,7 +307,7 @@ async function doOverwatchCase() {
 
 								await new Promise(r => setTimeout(r, (timer * 1000)));
 							}
-							
+
 							// Check the Steam Web API, if a token is provided, if the user is already banned, if so always send a conviction even if the bot didn't detect it
 							if (config.parsing.steamWebAPIKey && config.parsing.steamWebAPIKey.length >= 10) {
 								let banChecker = await new Promise((resolve, reject) => {
@@ -346,7 +351,7 @@ async function doOverwatchCase() {
 									data.curcasetempdata.wasAlreadyConvicted = false;
 								}
 							}
-							
+
 							if(convictionObj.rpt_aimbot || convictionObj.rpt_wallhack || convictionObj.rpt_speedhack || convictionObj.rpt_teamharm) {
 								data.curcasetempdata.Reported = true;
 							} else {
@@ -390,6 +395,7 @@ async function doOverwatchCase() {
 							console.log("	Aimbot: " + data.curcasetempdata.aimbot_infractions.length);
 							console.log("	Wallhack: " + data.curcasetempdata.Wallhack_infractions.length);
 							console.log("	TeamKills: " + data.curcasetempdata.teamKill_infractions.length);
+							console.log("	TeamDamage: " + data.curcasetempdata.teamDamage_infractions);
 							console.log("	Other: 0");
 							console.log("	Griefing: " + data.curcasetempdata.AFKing_infractions.length);
 							console.log("	Reported: " +(data.curcasetempdata.Reported ? "Yes" : "No"));

--- a/index.js
+++ b/index.js
@@ -9,6 +9,7 @@ const SteamID = require("steamid");
 const Aimbot = require("./detectors/aimbot.js");
 const AFKing = require("./detectors/AFKing.js");
 const Wallhack = require("./detectors/wallhack.js");
+const TeamKill = require("./detectors/teamkill.js");
 
 const Helper = require("./helpers/Helper.js");
 const GameCoordinator = require("./helpers/GameCoordinator.js");
@@ -49,6 +50,7 @@ let data = {
 		aimbot_infractions: [],
 		AFKing_infractions: [],
 		Wallhack_infractions: [],
+		teamKill_infractions: [],
 		Reported: false
 	}
 };
@@ -229,6 +231,7 @@ async function doOverwatchCase() {
 						data.curcasetempdata.aimbot_infractions = [];
 						data.curcasetempdata.AFKing_infractions = [];
 						data.curcasetempdata.Wallhack_infractions = [];
+						data.curcasetempdata.teamKill_infractions = [];
 						data.curcasetempdata.wasAlreadyConvicted = false;
 
 						let lastProg = -1;
@@ -251,6 +254,7 @@ async function doOverwatchCase() {
 						Aimbot(demoFile, sid, data, config);
 						AFKing(demoFile, sid, data, config);
 						Wallhack(demoFile, sid, data, config);
+						TeamKill(demoFile, sid, data);
 
 						demoFile.on("progress", (progressFraction) => {
 							let prog = Math.round(progressFraction * 100);
@@ -285,7 +289,7 @@ async function doOverwatchCase() {
 								rpt_aimbot: (data.curcasetempdata.aimbot_infractions.length > config.verdict.maxAimbot) ? 1 : 0,
 								rpt_wallhack: (data.curcasetempdata.Wallhack_infractions.length > config.verdict.maxWallKills) ? 1 : 0, // TODO: Add detection for looking at enemies through walls
 								rpt_speedhack: 0, // TODO: Add detection for other cheats (Ex BunnyHopping)
-								rpt_teamharm: (data.curcasetempdata.AFKing_infractions.length > config.verdict.maxAFKing) ? 1 : 0, // TODO: Add detection for damaging teammates
+								rpt_teamharm: (data.curcasetempdata.AFKing_infractions.length > config.verdict.maxAFKing || data.curcasetempdata.teamKill_infractions.length > config.verdict.maxTeamKills) ? 1 : 0, // TODO: Add detection for damaging teammates
 								reason: 3
 							};
 
@@ -383,6 +387,7 @@ async function doOverwatchCase() {
 							console.log("Infractions:");
 							console.log("	Aimbot: " + data.curcasetempdata.aimbot_infractions.length);
 							console.log("	Wallhack: " + data.curcasetempdata.Wallhack_infractions.length);
+							console.log("	TeamKills: " + data.curcasetempdata.teamKill_infractions.length);
 							console.log("	Other: 0");
 							console.log("	Griefing: " + data.curcasetempdata.AFKing_infractions.length);
 							console.log("	Reported: " +(data.curcasetempdata.Reported ? "Yes" : "No"));

--- a/index.js
+++ b/index.js
@@ -222,7 +222,9 @@ async function doOverwatchCase() {
 				fs.createReadStream("./demofile.bz2").pipe(bz2()).pipe(fs.createWriteStream("./demofile.dem")).on("close", () => {
 					data.unpacking.endTimestamp = Date.now();
 
-					fs.unlinkSync("./demofile.bz2");
+					if (fs.existsSync("./demofile.bz2")) {
+						fs.unlinkSync("./demofile.bz2");
+					}
 
 					data.parsing.startTimestamp = Date.now();
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -697,9 +697,9 @@
       "integrity": "sha1-hMinKrWcRyUyFIDJdeZQg0LnCTc="
     },
     "lodash": {
-      "version": "4.17.15",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+      "version": "4.17.19",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
+      "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ=="
     },
     "long": {
       "version": "3.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,21 +1,21 @@
 {
   "name": "csgo-overwatch-bot",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
     "@bbob/parser": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@bbob/parser/-/parser-2.2.0.tgz",
-      "integrity": "sha512-AmXNr8+PJ5cKjfVh10FmQGUHttqFGun5SbLh5HccM/GF9WD+TO6Y2z7lhSzLOPxFGjsgLyIihTjhBJ58Q7VW/A==",
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@bbob/parser/-/parser-2.5.6.tgz",
+      "integrity": "sha512-qBt88OQvjfkdHH7JhTzFSIU/zV6kwhiMchADnlFIkuRMWH8dSt6pmzPzjRQzS/v8NHGSwiKtTbC01AGGLOmmOA==",
       "requires": {
-        "@bbob/plugin-helper": "^2.0.1"
+        "@bbob/plugin-helper": "^2.5.6"
       }
     },
     "@bbob/plugin-helper": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@bbob/plugin-helper/-/plugin-helper-2.0.1.tgz",
-      "integrity": "sha512-zIDluUvCBoIf1Pp9aYNzeWvwz+oHIuFRN13csT3Fnfo4mIyDr+C2pMxVNCXYqsfgA3xZ0ZgqhR8sddpD49gxdw=="
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@bbob/plugin-helper/-/plugin-helper-2.5.6.tgz",
+      "integrity": "sha512-JQRr5aughtj9S2SyzK9kmalwbTEEpnDeyv21NRpPateehHUxiNM70QPERx/7mm4dVk21sEizUGYiMd61xfFXQQ=="
     },
     "@doctormckay/stats-reporter": {
       "version": "1.0.4",
@@ -23,9 +23,9 @@
       "integrity": "sha512-J8YqHQGZ3OdrT4xzWOzvA/p3vnXNnSOsAybPa5+02YE5U46JbZexfzU8nJV+2iN7GWhGvLAQNgdvFHl5WKB4iw=="
     },
     "@doctormckay/stdlib": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@doctormckay/stdlib/-/stdlib-1.10.0.tgz",
-      "integrity": "sha512-Sb1kpMGG/uKUg4oxDjUgFKJELncsEn9FESjeD6gx/mtCZsaxs5xN5KjjwCSmhR+aTLCTO+i+Vv8WZ5hGe6aqKQ=="
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/@doctormckay/stdlib/-/stdlib-1.10.2.tgz",
+      "integrity": "sha512-lBW0upY7Cgk+zbjDMH4q4tuvQ0ss+/jd2KMLHqboGw4p0Mc3RUJGhCkMS1c+eUNd6KbNE//F0DYJzNTYq5kjqg=="
     },
     "@doctormckay/steam-crypto": {
       "version": "1.2.0",
@@ -97,9 +97,9 @@
       "integrity": "sha512-e9wgeY6gaY21on3ve0xAjgBVjGDWq/xUteK0ujsE53bUoxycMkqfnkUgMt6ffZtykZ5X12Mg3T7Pw4TRCObDKg=="
     },
     "adm-zip": {
-      "version": "0.4.13",
-      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.4.13.tgz",
-      "integrity": "sha512-fERNJX8sOXfel6qCBCMPvZLzENBEhZTzKqg6vrOW5pvoEaQuJhRU4ndTAh6lHOxn1I6jnz2NHra56ZODM751uw=="
+      "version": "0.4.14",
+      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.4.14.tgz",
+      "integrity": "sha512-/9aQCnQHF+0IiCl0qhXoK7qs//SwYE7zX8lsr/DNk1BRAHYxeLZPL4pguwK29gUEqasYQjqPtEpDRSWEkdHn9g=="
     },
     "ajv": {
       "version": "6.9.2",
@@ -139,11 +139,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
       "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
-    },
-    "async": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-      "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
     },
     "asynckit": {
       "version": "0.4.0",
@@ -462,12 +457,9 @@
       }
     },
     "file-manager": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/file-manager/-/file-manager-1.0.1.tgz",
-      "integrity": "sha1-yZySdeSoyNr13vFR9rUUBVIegXo=",
-      "requires": {
-        "async": "^1.4.2"
-      }
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/file-manager/-/file-manager-2.0.0.tgz",
+      "integrity": "sha512-AX9jtqrrHK9JT4v3J7uMZGkDNiuuG4y4T6LoNm3lKzT/vReLCY8mnRWIpaG2ffNEpJHSkiwKejpu8x8THEYPzg=="
     },
     "forever-agent": {
       "version": "0.6.1",
@@ -800,9 +792,12 @@
       "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
     },
     "permessage-deflate": {
-      "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/permessage-deflate/-/permessage-deflate-0.1.6.tgz",
-      "integrity": "sha1-WB8c7fvUQPrEfQd3vohjM4a5kt4="
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/permessage-deflate/-/permessage-deflate-0.1.7.tgz",
+      "integrity": "sha512-EUNi/RIsyJ1P1u9QHFwMOUWMYetqlE22ZgGbad7YP856WF4BFF0B7DuNy6vEGsgNNud6c/SkdWzkne71hH8MjA==",
+      "requires": {
+        "safe-buffer": "*"
+      }
     },
     "process-nextick-args": {
       "version": "2.0.1",
@@ -962,42 +957,15 @@
       }
     },
     "steam-appticket": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/steam-appticket/-/steam-appticket-1.0.0.tgz",
-      "integrity": "sha512-PnHYAqTFIytTr6RFulX0b2scclsXJx//PyMPOAKqxZDk9NZw5Y4v9OLtPaG73Uh3d6a5ubbBbx464AfzKkre3w==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/steam-appticket/-/steam-appticket-1.0.1.tgz",
+      "integrity": "sha512-oYVInCvJlPPaQPYW1+iGcVP0N0ZvwtWiCDM1Z353XJ8l4DXQI/N+R5yyaRQcHRH5oQv3+BY6gPF40lu7gwEiJw==",
       "requires": {
         "@doctormckay/stdlib": "^1.6.0",
         "@doctormckay/steam-crypto": "^1.2.0",
         "bytebuffer": "^5.0.1",
         "protobufjs": "^6.8.8",
         "steamid": "^1.1.0"
-      },
-      "dependencies": {
-        "long": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
-          "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA=="
-        },
-        "protobufjs": {
-          "version": "6.8.8",
-          "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.8.8.tgz",
-          "integrity": "sha512-AAmHtD5pXgZfi7GMpllpO3q1Xw1OYldr+dMUlAnffGTAhqkg72WdmSY71uKBF/JuyiKs8psYbtKrhi0ASCD8qw==",
-          "requires": {
-            "@protobufjs/aspromise": "^1.1.2",
-            "@protobufjs/base64": "^1.1.2",
-            "@protobufjs/codegen": "^2.0.4",
-            "@protobufjs/eventemitter": "^1.1.0",
-            "@protobufjs/fetch": "^1.1.0",
-            "@protobufjs/float": "^1.0.2",
-            "@protobufjs/inquire": "^1.1.0",
-            "@protobufjs/path": "^1.1.2",
-            "@protobufjs/pool": "^1.1.0",
-            "@protobufjs/utf8": "^1.1.0",
-            "@types/long": "^4.0.0",
-            "@types/node": "^10.1.0",
-            "long": "^4.0.0"
-          }
-        }
       }
     },
     "steam-totp": {
@@ -1009,53 +977,25 @@
       }
     },
     "steam-user": {
-      "version": "4.4.4",
-      "resolved": "https://registry.npmjs.org/steam-user/-/steam-user-4.4.4.tgz",
-      "integrity": "sha512-lum65yu6CP0FMkri6WZ7ZW0V9iM/11fz1mC+VOE/3phkjtCusIQV+vteNQK9XmHb/o6nWE0s+R6lcSmsfOQVGA==",
+      "version": "4.15.3",
+      "resolved": "https://registry.npmjs.org/steam-user/-/steam-user-4.15.3.tgz",
+      "integrity": "sha512-QVbprj1BRoxdamBJKLsr7CREJ2bHp4FAmlBWOodtS2CDSjGBrY7T5UmaML2rWZqGUit4RP/WL53OkP4abiMPpA==",
       "requires": {
         "@bbob/parser": "^2.2.0",
-        "@doctormckay/stats-reporter": "^1.0.3",
         "@doctormckay/stdlib": "^1.6.0",
         "@doctormckay/steam-crypto": "^1.2.0",
         "adm-zip": "^0.4.13",
         "appdirectory": "^0.1.0",
         "binarykvparser": "^2.2.0",
         "bytebuffer": "^5.0.0",
-        "file-manager": "^1.0.1",
+        "file-manager": "^2.0.0",
         "lzma": "^2.3.2",
         "protobufjs": "^6.8.8",
-        "steam-appticket": "^1.0.0",
+        "steam-appticket": "^1.0.1",
         "steam-totp": "^2.0.1",
         "steamid": "^1.1.0",
         "vdf": "^0.0.2",
         "websocket13": "^2.0.1"
-      },
-      "dependencies": {
-        "long": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
-          "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA=="
-        },
-        "protobufjs": {
-          "version": "6.8.8",
-          "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.8.8.tgz",
-          "integrity": "sha512-AAmHtD5pXgZfi7GMpllpO3q1Xw1OYldr+dMUlAnffGTAhqkg72WdmSY71uKBF/JuyiKs8psYbtKrhi0ASCD8qw==",
-          "requires": {
-            "@protobufjs/aspromise": "^1.1.2",
-            "@protobufjs/base64": "^1.1.2",
-            "@protobufjs/codegen": "^2.0.4",
-            "@protobufjs/eventemitter": "^1.1.0",
-            "@protobufjs/fetch": "^1.1.0",
-            "@protobufjs/float": "^1.0.2",
-            "@protobufjs/inquire": "^1.1.0",
-            "@protobufjs/path": "^1.1.2",
-            "@protobufjs/pool": "^1.1.0",
-            "@protobufjs/utf8": "^1.1.0",
-            "@types/long": "^4.0.0",
-            "@types/node": "^10.1.0",
-            "long": "^4.0.0"
-          }
-        }
       }
     },
     "steamid": {
@@ -1201,9 +1141,9 @@
       "integrity": "sha512-nqHUnMXmBzT0w570r2JpJxfiSD1IzoI+HGVdd3aZ0yNi3ngvQ4jv1dtHt5VGxfI2yj5yqImPhOK4vmIh2xMbGg=="
     },
     "websocket13": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/websocket13/-/websocket13-2.0.1.tgz",
-      "integrity": "sha512-yElBD0vCOiG+vZgokIWicKvWN9tEy/+X5KK6S6LSw6JJMh5ZTEv1H7oDpcdKGES/dyfwmppTpnqwnxtIiXibNQ==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/websocket13/-/websocket13-2.1.1.tgz",
+      "integrity": "sha512-vnwuDSohh0G+vt65UBVXnt/vlEwg+cv7QE9Lv0x37ljWamiH+lVuEYe/eBugb6q29jaX8FU+kAWFb1XNGy41Ew==",
       "requires": {
         "@doctormckay/stdlib": "^1.8.0",
         "bytebuffer": "^5.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1136,9 +1136,9 @@
       }
     },
     "websocket-extensions": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.3.tgz",
-      "integrity": "sha512-nqHUnMXmBzT0w570r2JpJxfiSD1IzoI+HGVdd3aZ0yNi3ngvQ4jv1dtHt5VGxfI2yj5yqImPhOK4vmIh2xMbGg=="
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.4.tgz",
+      "integrity": "sha512-OqedPIGOfsDlo31UNwYbCFMSaO9m9G/0faIHj5/dZFDMFqPTcx6UwqyOy3COEaEOg/9VsGIpdqn62W5KhoKSpg=="
     },
     "websocket13": {
       "version": "2.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "csgo-overwatch-bot",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "description": "",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "protobufjs": "^6.8.8",
     "request": "^2.88.0",
     "steam-totp": "^2.1.0",
-    "steam-user": "^4.4.4",
+    "steam-user": "^4.15.3",
     "steamid": "^1.1.0",
     "unbzip2-stream": "^1.3.1",
     "unzipper": "^0.10.1",


### PR DESCRIPTION
Test build from #74

> I add this for better testing. Maybe anybody can share with me with any info for better detects or confirm what this method work success :eyes:

Need a bit more tests, but for `force.js` this test feature is good choice.
Later, maybe, this feature moved to main file (index.js) and help all for detect AA in **overwatch mode** instantly.

todo:

- [x] Try detect  **Rage AA**
- [ ] Try detect **Legit AA**
- [ ] Try detect **Desync**

In current time this feature is `beta`.
Detector can detect players without cheats like a players with cheats (AA).
If `AA detects < 20` I think this is false positive.
If `AA detects > 30` I think this is can be a true detect AA.

In test with no cheaters and cheaters players.
**Cheater have 56 detects.** So, I think, hvh boys can have more like 40 detects per game. 