### PR TITLE
URL for SteamID64

### DIFF
--- a/index.js
+++ b/index.js
@@ -182,7 +182,7 @@ coordinator.on("receivedFromGC", async (msgType, payload) => {
 		console.log("            Total Rounds: " + body.numrounds);
 		console.log("         Rounds to watch: " + body.fractionrounds);
 		console.log("Overwatch starting round: " + (body.fractionid + 1)); // FractionID 0 = Round 1 (Pistol round)
-		console.log("                 Suspect: " + sid.getSteamID64());
+		console.log("                 Suspect: https://steamcommunity.com/profiles/" + sid.getSteamID64());
 		console.log("----- The whole demo will be analyzed ----");
 		console.log("Downloading demo...");
 


### PR DESCRIPTION
Suggested by Cole and many others on SinlyxeCord and a few other discords as well,  just adds `https://steamcommunity.com/profiles/` to the suspects SteamID64 thus enabling easy copypaste + it also enables support for CTRL+Click in terminals where supported. idk if adding a trailing slash was really required but w/e

ofc it can be added as an update by yourself too in the future as well

nice release btw

