### PR TITLE
Antiaim detector fix

### DIFF
--- a/config.json.example
+++ b/config.json.example
@@ -40,7 +40,7 @@
 		"minAimbot": 15,
 		"minWallKills": 5,
 		"minAFKing": 5,
-		"minAntiAim": 20,
+		"minAntiAim": 1,
 		"minTeamKills": 2,
 		"minTeamDamage": 150,
 		"minBhop": 15

--- a/detectors/AntiAim.js
+++ b/detectors/AntiAim.js
@@ -11,6 +11,7 @@ const NormalizeAsYaw = function (flAngle) {
 	
 		return flAngle;
 	}
+var old_m_vecOrigin = { x: 0, y: 0, z: 0 }
 
 // This class name MUST be unique or it will override other results
 module.exports = class AntiAim {
@@ -82,9 +83,15 @@ module.exports = class AntiAim {
 		// ! this detector can say what he have AntiAim (AA)... need more tests!
 		// ? Idea: https://www.unknowncheats.me/forum/counterstrike-global-offensive/208735-detecting-player-antiaim.html
 		const m_flLowerBodyYawTarget = this.parent.suspectPlayer.getProp("DT_CSPlayer", "m_flLowerBodyYawTarget");
+		const m_vecOrigin = this.parent.suspectPlayer.getProp("DT_CSNonLocalPlayerExclusive", "m_vecOrigin");
 		const eyeAngles = this.parent.suspectPlayer.eyeAngles;
 		const lbyDelta = m_flLowerBodyYawTarget - eyeAngles.yaw;
-		if (lbyDelta <= 40 || currentWeaponIsGrenade() || eyeAngles.pitch !== 0 || eyeAngles.yaw !== 0) {
+		var is_moving = true
+		if (JSON.stringify(m_vecOrigin) === JSON.stringify(old_m_vecOrigin)){
+			is_moving = false //if he is moving the detector will detect many false positives
+		}
+		old_m_vecOrigin = this.parent.suspectPlayer.getProp("DT_CSNonLocalPlayerExclusive", "m_vecOrigin");
+		if (lbyDelta <= 40 || currentWeaponIsGrenade() || eyeAngles.pitch !== 0 ||  !is_moving || eyeAngles.yaw !== 0) {
 			// ? if I didn't check yaw I get false positive sometimes. 
 			// ? but in rage cheater what really have AA detects didn't increase or decrease
 			// All good

--- a/detectors/AntiAim.js
+++ b/detectors/AntiAim.js
@@ -87,7 +87,9 @@ module.exports = class AntiAim {
 		const eyeAngles = this.parent.suspectPlayer.eyeAngles;
 		const yaw = NormalizeAsYaw(this.parent.suspectPlayer.eyeAngles.yaw);
 		const lbyDelta = m_flLowerBodyYawTarget - yaw;
-		const delta = lbyDelta >= 35 && lbyDelta <= 230;
+		const delta = lbyDelta >= 20 && lbyDelta <= 230;
+		const sequence = this.parent.suspectPlayer.props.DT_Animationlayer.m_nSequence;
+		const wrong_seq = sequence === 126 
 		const round = this.parent.demo.gameRules.props.DT_CSGameRules.m_totalRoundsPlayed
 		var is_moving = true
 		
@@ -98,7 +100,7 @@ module.exports = class AntiAim {
 		if (!delta){
 			return;
 		}
-		if (currentWeaponIsGrenade() || !is_moving || yaw > 40 || round != old_round) {
+		if (currentWeaponIsGrenade() || wrong_seq || !is_moving || yaw > 40 || round != old_round) {
 			old_round = this.parent.demo.gameRules.props.DT_CSGameRules.m_totalRoundsPlayed
 			return;
 		}

--- a/detectors/AntiAim.js
+++ b/detectors/AntiAim.js
@@ -87,8 +87,7 @@ module.exports = class AntiAim {
 		const eyeAngles = this.parent.suspectPlayer.eyeAngles;
 		const yaw = NormalizeAsYaw(this.parent.suspectPlayer.eyeAngles.yaw);
 		const lbyDelta = m_flLowerBodyYawTarget - yaw;
-		const delta1 = lbyDelta >= 20 && lbyDelta <= 60;
-		const delta2 = lbyDelta >= 250 && lbyDelta <= 300;
+		const delta = lbyDelta >= 19 && lbyDelta <= 230;
 		const round = this.parent.demo.gameRules.props.DT_CSGameRules.m_totalRoundsPlayed
 		var is_moving = true
 		
@@ -96,7 +95,7 @@ module.exports = class AntiAim {
 			is_moving = false
 		}
 		old_m_vecOrigin = this.parent.suspectPlayer.getProp("DT_CSNonLocalPlayerExclusive", "m_vecOrigin");
-		if (!delta1 === !delta2){
+		if (!delta){
 			return;
 		}
 		if (currentWeaponIsGrenade() || !is_moving || yaw > 40 || round != old_round) {

--- a/detectors/AntiAim.js
+++ b/detectors/AntiAim.js
@@ -64,6 +64,18 @@ module.exports = class AntiAim {
 			return;
 		
 
+		const weapon = this.parent.suspectPlayer.weapon ? this.parent.suspectPlayer.weapon.className : null;
+		const currentWeaponIsGrenade = () => {
+			const weapons = [
+				"weapon_hegrenade",
+				"weapon_flashbang",
+				"weapon_smokegrenade",
+				"weapon_decoy",
+				"weapon_incgrenade",
+				"weapon_molotov",
+			];
+			return weapons.includes(weapon);
+		};
 		// Check if player look at floor and check angles
 		// ! Be aware. This detector is unstable. 
 		// ! I don't sure by 100%, but if player just look at floor (0deg) and didn't kill anybody
@@ -72,7 +84,7 @@ module.exports = class AntiAim {
 		const m_flLowerBodyYawTarget = this.parent.suspectPlayer.getProp("DT_CSPlayer", "m_flLowerBodyYawTarget");
 		const eyeAngles = this.parent.suspectPlayer.eyeAngles;
 		const lbyDelta = m_flLowerBodyYawTarget - eyeAngles.yaw;
-		if (lbyDelta <= 40 || eyeAngles.pitch !== 0 || eyeAngles.yaw !== 0) {
+		if (lbyDelta <= 40 || currentWeaponIsGrenade() || eyeAngles.pitch !== 0 || eyeAngles.yaw !== 0) {
 			// ? if I didn't check yaw I get false positive sometimes. 
 			// ? but in rage cheater what really have AA detects didn't increase or decrease
 			// All good

--- a/detectors/AntiAim.js
+++ b/detectors/AntiAim.js
@@ -87,7 +87,7 @@ module.exports = class AntiAim {
 		const eyeAngles = this.parent.suspectPlayer.eyeAngles;
 		const yaw = NormalizeAsYaw(this.parent.suspectPlayer.eyeAngles.yaw);
 		const lbyDelta = m_flLowerBodyYawTarget - yaw;
-		const delta = lbyDelta >= 19 && lbyDelta <= 230;
+		const delta = lbyDelta >= 35 && lbyDelta <= 230;
 		const round = this.parent.demo.gameRules.props.DT_CSGameRules.m_totalRoundsPlayed
 		var is_moving = true
 		

--- a/detectors/AntiAim.js
+++ b/detectors/AntiAim.js
@@ -1,3 +1,5 @@
+var old_m_vecOrigin = { x: 0, y: 0, z: 0 }
+var old_round = -1
 const NormalizeAsYaw = function (flAngle) {
 		if (flAngle > 180 || flAngle < -180)
 		{
@@ -11,8 +13,6 @@ const NormalizeAsYaw = function (flAngle) {
 	
 		return flAngle;
 	}
-var old_m_vecOrigin = { x: 0, y: 0, z: 0 }
-var old_round = -1
 
 // This class name MUST be unique or it will override other results
 module.exports = class AntiAim {
@@ -62,8 +62,7 @@ module.exports = class AntiAim {
 			|| !this.parent.suspectPlayer.isAlive
 			|| this.parent.demo.gameRules.isWarmup
 			|| this.parent.demo.gameRules.props.DT_CSGameRules.m_bFreezePeriod)
-			// Suspect left or is dead or in freezeperiod
-			return;
+			return; 
 		
 
 		const weapon = this.parent.suspectPlayer.weapon ? this.parent.suspectPlayer.weapon.className : null;
@@ -88,25 +87,23 @@ module.exports = class AntiAim {
 		const eyeAngles = this.parent.suspectPlayer.eyeAngles;
 		const yaw = NormalizeAsYaw(this.parent.suspectPlayer.eyeAngles.yaw);
 		const lbyDelta = m_flLowerBodyYawTarget - yaw;
-		const delta1= lbyDelta >= 20 && lbyDelta <= 60;
+		const delta1 = lbyDelta >= 20 && lbyDelta <= 60;
 		const delta2 = lbyDelta >= 250 && lbyDelta <= 300;
 		const round = this.parent.demo.gameRules.props.DT_CSGameRules.m_totalRoundsPlayed
 		var is_moving = true
 		
 		if (JSON.stringify(m_vecOrigin) === JSON.stringify(old_m_vecOrigin)){
-			is_moving = false //if he is moving the detector will detect many false positives
+			is_moving = false
 		}
-		
+		old_m_vecOrigin = this.parent.suspectPlayer.getProp("DT_CSNonLocalPlayerExclusive", "m_vecOrigin");
 		if (!delta1 === !delta2){
 			return;
 		}
-		
-		old_m_vecOrigin = this.parent.suspectPlayer.getProp("DT_CSNonLocalPlayerExclusive", "m_vecOrigin");
-		
-		if ( currentWeaponIsGrenade() ||  !is_moving ||  yaw > 40 || round != old_round) {
-			old_round = this.parent.demo.gameRules.props.DT_CSGameRules.m_totalRoundsPlayed //sometimes at round start there is one false posive
+		if (currentWeaponIsGrenade() || !is_moving || yaw > 40 || round != old_round) {
+			old_round = this.parent.demo.gameRules.props.DT_CSGameRules.m_totalRoundsPlayed
 			return;
 		}
+
 		
 		old_round = this.parent.demo.gameRules.props.DT_CSGameRules.m_totalRoundsPlayed
 

--- a/detectors/AntiAim.js
+++ b/detectors/AntiAim.js
@@ -1,3 +1,17 @@
+const NormalizeAsYaw = function (flAngle) {
+		if (flAngle > 180 || flAngle < -180)
+		{
+			var revolutions = Math.round(Math.abs(flAngle / 360));
+	
+			if (flAngle < 0)
+				flAngle += 360 * revolutions;
+			else
+				flAngle -= 360 * revolutions;
+		}
+	
+		return flAngle;
+	}
+
 // This class name MUST be unique or it will override other results
 module.exports = class AntiAim {
 	constructor(parent, config) {
@@ -42,10 +56,13 @@ module.exports = class AntiAim {
 	 * Custom Methods *
 	 ******************/
 	OnTickEnd(tick) {
-		if (!this.parent.suspectPlayer || !this.parent.suspectPlayer.isAlive) {
-			// Suspect left or is dead
+		if (!this.parent.suspectPlayer
+			|| !this.parent.suspectPlayer.isAlive
+			|| this.parent.demo.gameRules.isWarmup
+			|| this.parent.demo.gameRules.props.DT_CSGameRules.m_bFreezePeriod)
+			// Suspect left or is dead or in freezeperiod
 			return;
-		}
+		
 
 		// Check if player look at floor and check angles
 		// ! Be aware. This detector is unstable. 


### PR DESCRIPTION
Well this shouldn't give you false positives in 99% of the cases. The only real false positive from 150 suspects was a suspect who was doing +left in console, which broke the animation one time. Also I got 2 possible false positives, but these suspects were raging and I could not see any legit AA, but I think there was one. There were also 6 possible false negatives, which were spinbots, but they could have disabled desync and since I don't check  for pitch down, those were not detected.
From 150 cases 141 where correct. But keep in mind that the threshold has to be >= 1. Also this CAN detect legit AA.
Maybe the possible false negatives can be detected, if we change the lby_delta treshold, but this is trial and error.